### PR TITLE
Fix a minor script issue which caused the configure-hadoop.sh to fail

### DIFF
--- a/OnDemandYARNClusters/rm_docker_ubuntu/init-script
+++ b/OnDemandYARNClusters/rm_docker_ubuntu/init-script
@@ -20,7 +20,7 @@ sed -i 's/AddUdevRules(list/#AddUdevRules(list/' /opt/mapr/server/disksetup
 
 # Disable JHS configuration from configure-hadoop.sh
 sed -i 's/ConfigureMyriadJHSAdd /#ConfigureMyriadJHSAdd /' /opt/mapr/server/configure-hadoop.sh
-sed -i 's/ConfigureMyriadJHSInsert /#ConfigureMyriadJHSInsert /' /opt/mapr/server/configure-hadoop.sh
+sed -i 's/ConfigureMyriadJHSInsert /echo "Disable JHS configuration" #ConfigureMyriadJHSInsert /' /opt/mapr/server/configure-hadoop.sh
 
 # Add user & group for mapr.
 addgroup --gid 500 mapr


### PR DESCRIPTION
Fix a minor script issue which caused the configure-hadoop.sh to fail
